### PR TITLE
Enable CodeQL static code analysis scans

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,13 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  call:
+    uses: opiproject/opi-smbios-bridge/.github/workflows/codeql.yml@main
+    secrets: inherit


### PR DESCRIPTION
CodeQL scans are supposed to harden our code against potential security issues. The code is going to be checked against default security DB for go and additionally against security-extended and security-and-quality DBs. Additional benefit is the improvement of OSSF score for the project.