### PR TITLE
fix(issue160): hierarchical command structure

### DIFF
--- a/cmd/inventory-get.go
+++ b/cmd/inventory-get.go
@@ -43,3 +43,23 @@ func NewGetCommand() *cobra.Command {
 	flags.StringVar(&addr, "addr", "localhost:50151", "address of OPI gRPC server")
 	return cmd
 }
+
+// NewInventoryCommand tests the  inventory
+func NewInventoryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "inventory",
+		Aliases: []string{"g"},
+		Short:   "Tests inventory functionality",
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := cmd.Help()
+			if err != nil {
+				log.Fatalf("[ERROR] %s", err.Error())
+			}
+		},
+	}
+
+	cmd.AddCommand(NewGetCommand())
+
+	return cmd
+}

--- a/cmd/ipsec-stats.go
+++ b/cmd/ipsec-stats.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/opiproject/godpu/ipsec"
 	"github.com/spf13/cobra"
@@ -28,5 +29,25 @@ func NewStatsCommand() *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&addr, "addr", "localhost:50151", "address or OPI gRPC server")
+	return cmd
+}
+
+// NewIPSecCommand tests the  inventory
+func NewIPSecCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ipsec",
+		Aliases: []string{"g"},
+		Short:   "Tests ipsec functionality",
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := cmd.Help()
+			if err != nil {
+				log.Fatalf("[ERROR] %s", err.Error())
+			}
+		},
+	}
+
+	cmd.AddCommand(NewStatsCommand())
+	cmd.AddCommand(NewTestCommand())
 	return cmd
 }

--- a/cmd/storage-test.go
+++ b/cmd/storage-test.go
@@ -22,7 +22,7 @@ func NewStorageTestCommand() *cobra.Command {
 		addr string
 	)
 	cmd := &cobra.Command{
-		Use:     "storagetest",
+		Use:     "test",
 		Aliases: []string{"s"},
 		Short:   "Test storage functionality",
 		Args:    cobra.NoArgs,
@@ -70,5 +70,24 @@ func NewStorageTestCommand() *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&addr, "addr", "localhost:50151", "address or OPI gRPC server")
+	return cmd
+}
+
+// NewStorageCommand tests the storage functionality
+func NewStorageCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "storage",
+		Aliases: []string{"g"},
+		Short:   "Tests storage functionality",
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := cmd.Help()
+			if err != nil {
+				log.Fatalf("[ERROR] %s", err.Error())
+			}
+		},
+	}
+
+	cmd.AddCommand(NewStorageTestCommand())
 	return cmd
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     depends_on:
       opi-smbios-server:
         condition: service_healthy
-    command: get --addr opi-smbios-server:50051
+    command: inventory get --addr opi-smbios-server:50051
 
   opi-test:
     build:
@@ -83,7 +83,7 @@ services:
     depends_on:
       opi-spdk-server:
         condition: service_healthy
-    command: storagetest --addr opi-spdk-server:50051
+    command: storage test --addr opi-spdk-server:50051
 
 networks:
   opi:

--- a/main.go
+++ b/main.go
@@ -35,10 +35,9 @@ func newCommand() *cobra.Command {
 			os.Exit(1)
 		},
 	}
-	c.AddCommand(cmd.NewGetCommand())
-	c.AddCommand(cmd.NewTestCommand())
-	c.AddCommand(cmd.NewStatsCommand())
-	c.AddCommand(cmd.NewStorageTestCommand())
+	c.AddCommand(cmd.NewInventoryCommand())
+	c.AddCommand(cmd.NewIPSecCommand())
+	c.AddCommand(cmd.NewStorageCommand())
 	c.AddCommand(cmd.NewEvpnCommand())
 	return c
 }


### PR DESCRIPTION
Current                           NOW(with HIERARCHY)
godpu get                  --->   godpu inventory get
godpu stats                --->   godpu ipsec stats
godpu test                  --->   godpu ipsec test
godpu storage-test    --->   godpu storage test
![image](https://github.com/opiproject/godpu/assets/88648151/d588a306-68b6-4fb3-b101-945ddecedfee)
![image](https://github.com/opiproject/godpu/assets/88648151/ba44228c-b972-4da0-ad38-b38efcc05962)
