### PR TITLE
Revert "fix: opi-test is started only when all dependent services completed"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@
 version: "3.7"
 
 services:
+
   spdk:
     image: docker.io/opiproject/spdk:v23.09
     volumes:
@@ -123,14 +124,9 @@ services:
     networks:
       - opi
     depends_on:
-      opi-evpn-test:
-        condition: service_completed_successfully
-      opi-smbios-test:
-        condition: service_completed_successfully
-      opi-storage-test:
-        condition: service_completed_successfully
-    command: |
-      sh -c 'exit 0'
+      - opi-evpn-test
+      - opi-smbios-test
+      - opi-storage-test
 
 networks:
   opi:


### PR DESCRIPTION
Reverts opiproject/godpu#349 since it was not ready