### PR TITLE
feat(storage): add create/delete cli calls for nvme tcp/pcie controllers

### DIFF
--- a/cmd/storage-nvme-controller.go
+++ b/cmd/storage-nvme-controller.go
@@ -70,3 +70,37 @@ func newCreateNvmeControllerTCPCommand() *cobra.Command {
 
 	return cmd
 }
+
+func newDeleteNvmeControllerCommand() *cobra.Command {
+	name := ""
+	allowMissing := false
+	cmd := &cobra.Command{
+		Use:     "controller",
+		Aliases: []string{"c"},
+		Short:   "Deletes nvme controller",
+		Args:    cobra.NoArgs,
+		Run: func(c *cobra.Command, args []string) {
+			addr, err := c.Flags().GetString(addrCmdLineArg)
+			cobra.CheckErr(err)
+
+			timeout, err := c.Flags().GetDuration(timeoutCmdLineArg)
+			cobra.CheckErr(err)
+
+			client, err := storage.New(addr)
+			cobra.CheckErr(err)
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			err = client.DeleteNvmeController(ctx, name, allowMissing)
+			cobra.CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "name of deleted controller")
+	cmd.Flags().BoolVar(&allowMissing, "allowMissing", false, "cmd succeeds if attempts to delete a resource that is not present")
+
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
+
+	return cmd
+}

--- a/cmd/storage-nvme-controller.go
+++ b/cmd/storage-nvme-controller.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Intel Corporation
+
+// Package cmd implements the CLI commands
+package cmd
+
+import (
+	"context"
+	"net"
+
+	"github.com/opiproject/godpu/storage"
+	"github.com/spf13/cobra"
+)
+
+func newCreateNvmeControllerCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "controller",
+		Aliases: []string{"c"},
+		Short:   "Creates nvme controller",
+		Args:    cobra.NoArgs,
+		Run: func(c *cobra.Command, args []string) {
+			err := c.Help()
+			cobra.CheckErr(err)
+		},
+	}
+
+	cmd.AddCommand(newCreateNvmeControllerTCPCommand())
+
+	return cmd
+}
+
+func newCreateNvmeControllerTCPCommand() *cobra.Command {
+	id := ""
+	subsystem := ""
+	var ip net.IP
+	var port uint16
+	cmd := &cobra.Command{
+		Use:     "tcp",
+		Aliases: []string{"t"},
+		Short:   "Creates nvme TCP controller",
+		Args:    cobra.NoArgs,
+		Run: func(c *cobra.Command, args []string) {
+			addr, err := c.Flags().GetString(addrCmdLineArg)
+			cobra.CheckErr(err)
+
+			timeout, err := c.Flags().GetDuration(timeoutCmdLineArg)
+			cobra.CheckErr(err)
+
+			client, err := storage.New(addr)
+			cobra.CheckErr(err)
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			response, err := client.CreateNvmeTCPController(ctx, id, subsystem, ip, port)
+			cobra.CheckErr(err)
+
+			printResponse(response.Name)
+		},
+	}
+
+	cmd.Flags().StringVar(&id, "id", "", "id for created resource. Assigned by server if omitted.")
+	cmd.Flags().StringVar(&subsystem, "subsystem", "", "subsystem name to attach the controller to")
+	cmd.Flags().IPVar(&ip, "ip", nil, "ip address of the created controller")
+	cmd.Flags().Uint16Var(&port, "port", 0, "port of the created controller")
+
+	cobra.CheckErr(cmd.MarkFlagRequired("subsystem"))
+	cobra.CheckErr(cmd.MarkFlagRequired("ip"))
+	cobra.CheckErr(cmd.MarkFlagRequired("port"))
+
+	return cmd
+}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -70,6 +70,7 @@ func newCreateNvmeCommand() *cobra.Command {
 
 	cmd.AddCommand(newCreateNvmeSubsystemCommand())
 	cmd.AddCommand(newCreateNvmeNamespaceCommand())
+	cmd.AddCommand(newCreateNvmeControllerCommand())
 
 	return cmd
 }

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -106,6 +106,7 @@ func newDeleteNvmeCommand() *cobra.Command {
 
 	cmd.AddCommand(newDeleteNvmeSubsystemCommand())
 	cmd.AddCommand(newDeleteNvmeNamespaceCommand())
+	cmd.AddCommand(newDeleteNvmeControllerCommand())
 
 	return cmd
 }

--- a/storage/nvme_controller.go
+++ b/storage/nvme_controller.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Intel Corporation
+
+// Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
+package storage
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+// CreateNvmeTCPController creates an nvme TCP controller
+func (c *Client) CreateNvmeTCPController(
+	ctx context.Context,
+	id, subsystem string,
+	ip net.IP,
+	port uint16,
+) (*pb.NvmeController, error) {
+	conn, connClose, err := c.connector.NewConn()
+	if err != nil {
+		return nil, err
+	}
+	defer connClose()
+
+	var adrfam pb.NvmeAddressFamily
+	switch {
+	case ip.To4() != nil:
+		adrfam = pb.NvmeAddressFamily_NVME_ADRFAM_IPV4
+	case ip.To16() != nil:
+		adrfam = pb.NvmeAddressFamily_NVME_ADRFAM_IPV6
+	default:
+		return nil, fmt.Errorf("invalid ip address format: %v", ip)
+	}
+
+	client := c.createClient(conn)
+	response, err := client.CreateNvmeController(
+		ctx,
+		&pb.CreateNvmeControllerRequest{
+			Parent:           subsystem,
+			NvmeControllerId: id,
+			NvmeController: &pb.NvmeController{
+				Spec: &pb.NvmeControllerSpec{
+					Trtype: pb.NvmeTransportType_NVME_TRANSPORT_TCP,
+					Endpoint: &pb.NvmeControllerSpec_FabricsId{
+						FabricsId: &pb.FabricsEndpoint{
+							Traddr:  ip.String(),
+							Trsvcid: fmt.Sprint(port),
+							Adrfam:  adrfam,
+						},
+					},
+				},
+			},
+		})
+
+	return response, err
+}

--- a/storage/nvme_controller.go
+++ b/storage/nvme_controller.go
@@ -57,3 +57,26 @@ func (c *Client) CreateNvmeTCPController(
 
 	return response, err
 }
+
+// DeleteNvmeController deletes an nvme controller
+func (c *Client) DeleteNvmeController(
+	ctx context.Context,
+	name string,
+	allowMissing bool,
+) error {
+	conn, connClose, err := c.connector.NewConn()
+	if err != nil {
+		return err
+	}
+	defer connClose()
+
+	client := c.createClient(conn)
+	_, err = client.DeleteNvmeController(
+		ctx,
+		&pb.DeleteNvmeControllerRequest{
+			Name:         name,
+			AllowMissing: allowMissing,
+		})
+
+	return err
+}

--- a/storage/nvme_controller_test.go
+++ b/storage/nvme_controller_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Intel Corporation
+
+// Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
+package storage
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/opiproject/godpu/mocks"
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestCreateNvmeTCPController(t *testing.T) {
+	controllerID := "nvmetcp0"
+	subsystemName := "subsysTcp0Name"
+	ipV4Addr := net.ParseIP("127.0.0.1")
+	ipV6Addr := net.ParseIP("::")
+	testIPV4Controller := &pb.NvmeController{
+		Spec: &pb.NvmeControllerSpec{
+			Trtype: pb.NvmeTransportType_NVME_TRANSPORT_TCP,
+			Endpoint: &pb.NvmeControllerSpec_FabricsId{
+				FabricsId: &pb.FabricsEndpoint{
+					Traddr:  ipV4Addr.String(),
+					Trsvcid: "4420",
+					Adrfam:  pb.NvmeAddressFamily_NVME_ADRFAM_IPV4,
+				},
+			},
+		},
+	}
+	testIPV6Controller := &pb.NvmeController{
+		Spec: &pb.NvmeControllerSpec{
+			Trtype: pb.NvmeTransportType_NVME_TRANSPORT_TCP,
+			Endpoint: &pb.NvmeControllerSpec_FabricsId{
+				FabricsId: &pb.FabricsEndpoint{
+					Traddr:  ipV6Addr.String(),
+					Trsvcid: "4420",
+					Adrfam:  pb.NvmeAddressFamily_NVME_ADRFAM_IPV6,
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		giveClientErr    error
+		giveConnectorErr error
+		giveIP           net.IP
+		wantErr          error
+		wantRequest      *pb.CreateNvmeControllerRequest
+		wantResponse     *pb.NvmeController
+		wantConnClosed   bool
+	}{
+		"successful call": {
+			giveConnectorErr: nil,
+			giveClientErr:    nil,
+			giveIP:           ipV4Addr,
+			wantErr:          nil,
+			wantRequest: &pb.CreateNvmeControllerRequest{
+				Parent:           subsystemName,
+				NvmeControllerId: controllerID,
+				NvmeController:   proto.Clone(testIPV4Controller).(*pb.NvmeController),
+			},
+			wantResponse:   proto.Clone(testIPV4Controller).(*pb.NvmeController),
+			wantConnClosed: true,
+		},
+		"client err": {
+			giveConnectorErr: nil,
+			giveClientErr:    errors.New("Some client error"),
+			giveIP:           ipV4Addr,
+			wantErr:          errors.New("Some client error"),
+			wantRequest: &pb.CreateNvmeControllerRequest{
+				Parent:           subsystemName,
+				NvmeControllerId: controllerID,
+				NvmeController:   proto.Clone(testIPV4Controller).(*pb.NvmeController),
+			},
+			wantResponse:   nil,
+			wantConnClosed: true,
+		},
+		"connector err": {
+			giveConnectorErr: errors.New("Some conn error"),
+			giveClientErr:    nil,
+			giveIP:           ipV4Addr,
+			wantErr:          errors.New("Some conn error"),
+			wantRequest:      nil,
+			wantResponse:     nil,
+			wantConnClosed:   false,
+		},
+		"ipv6 address": {
+			giveConnectorErr: nil,
+			giveClientErr:    nil,
+			giveIP:           ipV6Addr,
+			wantErr:          nil,
+			wantRequest: &pb.CreateNvmeControllerRequest{
+				Parent:           subsystemName,
+				NvmeControllerId: controllerID,
+				NvmeController:   proto.Clone(testIPV6Controller).(*pb.NvmeController),
+			},
+			wantResponse:   proto.Clone(testIPV6Controller).(*pb.NvmeController),
+			wantConnClosed: true,
+		},
+		"invalid address": {
+			giveConnectorErr: nil,
+			giveClientErr:    nil,
+			giveIP:           net.IP{},
+			wantErr:          errors.New("invalid ip address format: <nil>"),
+			wantRequest:      nil,
+			wantResponse:     nil,
+			wantConnClosed:   true,
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			mockClient := mocks.NewFrontendNvmeServiceClient(t)
+			if tt.wantRequest != nil {
+				toReturn := proto.Clone(tt.wantResponse).(*pb.NvmeController)
+				mockClient.EXPECT().CreateNvmeController(ctx, tt.wantRequest).
+					Return(toReturn, tt.giveClientErr)
+			}
+
+			connClosed := false
+			mockConn := mocks.NewConnector(t)
+			mockConn.EXPECT().NewConn().Return(
+				&grpc.ClientConn{},
+				func() { connClosed = true },
+				tt.giveConnectorErr,
+			)
+
+			c, _ := NewWithArgs(
+				mockConn,
+				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
+					return mockClient
+				},
+			)
+
+			response, err := c.CreateNvmeTCPController(
+				ctx,
+				controllerID,
+				subsystemName,
+				tt.giveIP,
+				4420,
+			)
+
+			require.Equal(t, tt.wantErr, err)
+			require.True(t, proto.Equal(response, tt.wantResponse))
+			require.Equal(t, tt.wantConnClosed, connClosed)
+		})
+	}
+}

--- a/storage/nvme_controller_test.go
+++ b/storage/nvme_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestCreateNvmeTCPController(t *testing.T) {
@@ -153,6 +154,76 @@ func TestCreateNvmeTCPController(t *testing.T) {
 
 			require.Equal(t, tt.wantErr, err)
 			require.True(t, proto.Equal(response, tt.wantResponse))
+			require.Equal(t, tt.wantConnClosed, connClosed)
+		})
+	}
+}
+
+func TestDeleteNvmeController(t *testing.T) {
+	testControllerName := "nvmetcp0Name"
+	testRequest := &pb.DeleteNvmeControllerRequest{
+		Name:         testControllerName,
+		AllowMissing: true,
+	}
+	tests := map[string]struct {
+		giveClientErr    error
+		giveConnectorErr error
+		wantErr          error
+		wantRequest      *pb.DeleteNvmeControllerRequest
+		wantConnClosed   bool
+	}{
+		"successful call": {
+			giveConnectorErr: nil,
+			giveClientErr:    nil,
+			wantErr:          nil,
+			wantRequest:      proto.Clone(testRequest).(*pb.DeleteNvmeControllerRequest),
+			wantConnClosed:   true,
+		},
+		"client err": {
+			giveConnectorErr: nil,
+			giveClientErr:    errors.New("Some client error"),
+			wantErr:          errors.New("Some client error"),
+			wantRequest:      proto.Clone(testRequest).(*pb.DeleteNvmeControllerRequest),
+			wantConnClosed:   true,
+		},
+		"connector err": {
+			giveConnectorErr: errors.New("Some conn error"),
+			giveClientErr:    nil,
+			wantErr:          errors.New("Some conn error"),
+			wantRequest:      nil,
+			wantConnClosed:   false,
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			mockClient := mocks.NewFrontendNvmeServiceClient(t)
+			if tt.wantRequest != nil {
+				mockClient.EXPECT().DeleteNvmeController(ctx, tt.wantRequest).
+					Return(&emptypb.Empty{}, tt.giveClientErr)
+			}
+
+			connClosed := false
+			mockConn := mocks.NewConnector(t)
+			mockConn.EXPECT().NewConn().Return(
+				&grpc.ClientConn{},
+				func() { connClosed = true },
+				tt.giveConnectorErr,
+			)
+
+			c, _ := NewWithArgs(
+				mockConn,
+				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
+					return mockClient
+				},
+			)
+
+			err := c.DeleteNvmeController(ctx, testControllerName, true)
+
+			require.Equal(t, tt.wantErr, err)
 			require.Equal(t, tt.wantConnClosed, connClosed)
 		})
 	}


### PR DESCRIPTION
```bash
ss0=$(/dpu storage create nvme subsystem --nqn nqn.2019-06.io.spdk:opicli0 --hostnqn nqn.2019-06.io.spdk:opi-host0 --id subsys0)
ss1=$(/dpu storage create nvme subsystem --nqn nqn.2019-06.io.spdk:opicli1 --id subsys1)
tcp0=$(/dpu storage create nvme controller tcp --subsystem "$ss0" --ip "127.0.0.1" --port 4420 --id nvmetcp0)
pcie0=$(/dpu storage create nvme controller pcie --subsystem "$ss1" --port 0 --pf 0 --vf 1 --id pcie0)

/dpu storage delete nvme controller --name "$pcie0"
/dpu storage delete nvme controller --name "$tcp0"
/dpu storage delete nvme subsystem --name "$ss1"
/dpu storage delete nvme subsystem --name "$ss0"
```