### PR TITLE
feat(storage): add create/delete cli calls for virtio-blk controllers 

### DIFF
--- a/cmd/storage-virtio-blk.go
+++ b/cmd/storage-virtio-blk.go
@@ -56,3 +56,37 @@ func newCreateVirtioBlkCommand() *cobra.Command {
 
 	return cmd
 }
+
+func newDeleteVirtioBlkCommand() *cobra.Command {
+	name := ""
+	allowMissing := false
+	cmd := &cobra.Command{
+		Use:     "blk",
+		Aliases: []string{"b"},
+		Short:   "Deletes virtio-blk controller",
+		Args:    cobra.NoArgs,
+		Run: func(c *cobra.Command, args []string) {
+			addr, err := c.Flags().GetString(addrCmdLineArg)
+			cobra.CheckErr(err)
+
+			timeout, err := c.Flags().GetDuration(timeoutCmdLineArg)
+			cobra.CheckErr(err)
+
+			client, err := storage.New(addr)
+			cobra.CheckErr(err)
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			err = client.DeleteVirtioBlk(ctx, name, allowMissing)
+			cobra.CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "name of deleted virtio-blk controller")
+	cmd.Flags().BoolVar(&allowMissing, "allowMissing", false, "cmd succeeds if attempts to delete a resource that is not present")
+
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
+
+	return cmd
+}

--- a/cmd/storage-virtio-blk.go
+++ b/cmd/storage-virtio-blk.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Intel Corporation
+
+// Package cmd implements the CLI commands
+package cmd
+
+import (
+	"context"
+
+	"github.com/opiproject/godpu/storage"
+	"github.com/spf13/cobra"
+)
+
+func newCreateVirtioBlkCommand() *cobra.Command {
+	id := ""
+	volume := ""
+	var port uint
+	var pf uint
+	var vf uint
+	var maxIoQPS uint
+	cmd := &cobra.Command{
+		Use:     "blk",
+		Aliases: []string{"b"},
+		Short:   "Creates virtio-blk controller",
+		Args:    cobra.NoArgs,
+		Run: func(c *cobra.Command, args []string) {
+			addr, err := c.Flags().GetString(addrCmdLineArg)
+			cobra.CheckErr(err)
+
+			timeout, err := c.Flags().GetDuration(timeoutCmdLineArg)
+			cobra.CheckErr(err)
+
+			client, err := storage.New(addr)
+			cobra.CheckErr(err)
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			response, err := client.CreateVirtioBlk(ctx, id, volume, port, pf, vf, maxIoQPS)
+			cobra.CheckErr(err)
+
+			printResponse(response.Name)
+		},
+	}
+
+	cmd.Flags().StringVar(&id, "id", "", "id for created resource. Assigned by server if omitted.")
+	cmd.Flags().StringVar(&volume, "volume", "", "volume name to attach to virtio-blk controller")
+	cmd.Flags().UintVar(&port, "port", 0, "port_id address part of the created controller")
+	cmd.Flags().UintVar(&pf, "pf", 0, "physical_function address part of the created controller")
+	cmd.Flags().UintVar(&vf, "vf", 0, "virtual_function address part of the created controller")
+	cmd.Flags().UintVar(&maxIoQPS, "max-io-qps", 0, "max io queue pairs")
+
+	cobra.CheckErr(cmd.MarkFlagRequired("volume"))
+	cobra.CheckErr(cmd.MarkFlagRequired("pf"))
+	cobra.CheckErr(cmd.MarkFlagRequired("vf"))
+
+	return cmd
+}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 
 // Package cmd implements the CLI commands
 package cmd
@@ -52,6 +52,7 @@ func newStorageCreateCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newCreateNvmeCommand())
+	cmd.AddCommand(newCreateVirtioCommand())
 
 	return cmd
 }
@@ -71,6 +72,23 @@ func newCreateNvmeCommand() *cobra.Command {
 	cmd.AddCommand(newCreateNvmeSubsystemCommand())
 	cmd.AddCommand(newCreateNvmeNamespaceCommand())
 	cmd.AddCommand(newCreateNvmeControllerCommand())
+
+	return cmd
+}
+
+func newCreateVirtioCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "virtio",
+		Aliases: []string{"v"},
+		Short:   "Creates virtio resource",
+		Args:    cobra.NoArgs,
+		Run: func(c *cobra.Command, args []string) {
+			err := c.Help()
+			cobra.CheckErr(err)
+		},
+	}
+
+	cmd.AddCommand(newCreateVirtioBlkCommand())
 
 	return cmd
 }

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -106,6 +106,7 @@ func newStorageDeleteCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newDeleteNvmeCommand())
+	cmd.AddCommand(newDeleteVirtioCommand())
 
 	return cmd
 }
@@ -125,6 +126,23 @@ func newDeleteNvmeCommand() *cobra.Command {
 	cmd.AddCommand(newDeleteNvmeSubsystemCommand())
 	cmd.AddCommand(newDeleteNvmeNamespaceCommand())
 	cmd.AddCommand(newDeleteNvmeControllerCommand())
+
+	return cmd
+}
+
+func newDeleteVirtioCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "virtio",
+		Aliases: []string{"v"},
+		Short:   "Deletes virtio resource",
+		Args:    cobra.NoArgs,
+		Run: func(c *cobra.Command, args []string) {
+			err := c.Help()
+			cobra.CheckErr(err)
+		},
+	}
+
+	cmd.AddCommand(newDeleteVirtioBlkCommand())
 
 	return cmd
 }

--- a/storage/client.go
+++ b/storage/client.go
@@ -14,17 +14,17 @@ import (
 
 const defaultTimeout = 10 * time.Second
 
-// CreateNvmeClient defines the function type used to retrieve FrontendNvmeServiceClient
-type CreateNvmeClient func(cc grpc.ClientConnInterface) pb.FrontendNvmeServiceClient
+// CreateFrontendNvmeClient defines the function type used to retrieve FrontendNvmeServiceClient
+type CreateFrontendNvmeClient func(cc grpc.ClientConnInterface) pb.FrontendNvmeServiceClient
 
-// CreateVirtioBlkClient defines the function type used to retrieve FrontendVirtioBlkServiceClient
-type CreateVirtioBlkClient func(cc grpc.ClientConnInterface) pb.FrontendVirtioBlkServiceClient
+// CreateFrontendVirtioBlkClient defines the function type used to retrieve FrontendVirtioBlkServiceClient
+type CreateFrontendVirtioBlkClient func(cc grpc.ClientConnInterface) pb.FrontendVirtioBlkServiceClient
 
 // Client is used for managing storage devices on OPI server
 type Client struct {
-	connector             grpcOpi.Connector
-	createClient          CreateNvmeClient
-	createVirtioBlkClient CreateVirtioBlkClient
+	connector                     grpcOpi.Connector
+	createFrontendNvmeClient      CreateFrontendNvmeClient
+	createFrontendVirtioBlkClient CreateFrontendVirtioBlkClient
 
 	timeout time.Duration
 }
@@ -46,13 +46,13 @@ func New(addr string) (*Client, error) {
 // NewWithArgs creates a new instance of Client with non-default members
 func NewWithArgs(
 	connector grpcOpi.Connector,
-	createClient CreateNvmeClient,
-	createVirtioBlkClient CreateVirtioBlkClient,
+	createFrontendNvmeClient CreateFrontendNvmeClient,
+	createFrontendVirtioBlkClient CreateFrontendVirtioBlkClient,
 ) (*Client, error) {
 	return &Client{
-		connector:             connector,
-		createClient:          createClient,
-		createVirtioBlkClient: createVirtioBlkClient,
-		timeout:               defaultTimeout,
+		connector:                     connector,
+		createFrontendNvmeClient:      createFrontendNvmeClient,
+		createFrontendVirtioBlkClient: createFrontendVirtioBlkClient,
+		timeout:                       defaultTimeout,
 	}, nil
 }

--- a/storage/client.go
+++ b/storage/client.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 
 // Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
 package storage
@@ -17,10 +17,14 @@ const defaultTimeout = 10 * time.Second
 // CreateNvmeClient defines the function type used to retrieve FrontendNvmeServiceClient
 type CreateNvmeClient func(cc grpc.ClientConnInterface) pb.FrontendNvmeServiceClient
 
+// CreateVirtioBlkClient defines the function type used to retrieve FrontendVirtioBlkServiceClient
+type CreateVirtioBlkClient func(cc grpc.ClientConnInterface) pb.FrontendVirtioBlkServiceClient
+
 // Client is used for managing storage devices on OPI server
 type Client struct {
-	connector    grpcOpi.Connector
-	createClient CreateNvmeClient
+	connector             grpcOpi.Connector
+	createClient          CreateNvmeClient
+	createVirtioBlkClient CreateVirtioBlkClient
 
 	timeout time.Duration
 }
@@ -35,6 +39,7 @@ func New(addr string) (*Client, error) {
 	return NewWithArgs(
 		connector,
 		pb.NewFrontendNvmeServiceClient,
+		pb.NewFrontendVirtioBlkServiceClient,
 	)
 }
 
@@ -42,10 +47,12 @@ func New(addr string) (*Client, error) {
 func NewWithArgs(
 	connector grpcOpi.Connector,
 	createClient CreateNvmeClient,
+	createVirtioBlkClient CreateVirtioBlkClient,
 ) (*Client, error) {
 	return &Client{
-		connector:    connector,
-		createClient: createClient,
-		timeout:      defaultTimeout,
+		connector:             connector,
+		createClient:          createClient,
+		createVirtioBlkClient: createVirtioBlkClient,
+		timeout:               defaultTimeout,
 	}, nil
 }

--- a/storage/nvme_controller.go
+++ b/storage/nvme_controller.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 
 // Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
 package storage
@@ -36,7 +36,7 @@ func (c *Client) CreateNvmeTCPController(
 		return nil, fmt.Errorf("invalid ip address format: %v", ip)
 	}
 
-	client := c.createClient(conn)
+	client := c.createFrontendNvmeClient(conn)
 	response, err := client.CreateNvmeController(
 		ctx,
 		&pb.CreateNvmeControllerRequest{
@@ -71,7 +71,7 @@ func (c *Client) CreateNvmePcieController(
 	}
 	defer connClose()
 
-	client := c.createClient(conn)
+	client := c.createFrontendNvmeClient(conn)
 	response, err := client.CreateNvmeController(
 		ctx,
 		&pb.CreateNvmeControllerRequest{
@@ -106,7 +106,7 @@ func (c *Client) DeleteNvmeController(
 	}
 	defer connClose()
 
-	client := c.createClient(conn)
+	client := c.createFrontendNvmeClient(conn)
 	_, err = client.DeleteNvmeController(
 		ctx,
 		&pb.DeleteNvmeControllerRequest{

--- a/storage/nvme_controller_test.go
+++ b/storage/nvme_controller_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 
 // Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
 package storage

--- a/storage/nvme_controller_test.go
+++ b/storage/nvme_controller_test.go
@@ -143,6 +143,7 @@ func TestCreateNvmeTCPController(t *testing.T) {
 				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
 					return mockClient
 				},
+				pb.NewFrontendVirtioBlkServiceClient,
 			)
 
 			response, err := c.CreateNvmeTCPController(
@@ -243,6 +244,7 @@ func TestCreateNvmePcieController(t *testing.T) {
 				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
 					return mockClient
 				},
+				pb.NewFrontendVirtioBlkServiceClient,
 			)
 
 			response, err := c.CreateNvmePcieController(
@@ -319,6 +321,7 @@ func TestDeleteNvmeController(t *testing.T) {
 				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
 					return mockClient
 				},
+				pb.NewFrontendVirtioBlkServiceClient,
 			)
 
 			err := c.DeleteNvmeController(ctx, testControllerName, true)

--- a/storage/nvme_namespace.go
+++ b/storage/nvme_namespace.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 
 // Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
 package storage
@@ -21,7 +21,7 @@ func (c *Client) CreateNvmeNamespace(
 	}
 	defer connClose()
 
-	client := c.createClient(conn)
+	client := c.createFrontendNvmeClient(conn)
 	response, err := client.CreateNvmeNamespace(
 		ctx,
 		&pb.CreateNvmeNamespaceRequest{
@@ -49,7 +49,7 @@ func (c *Client) DeleteNvmeNamespace(
 	}
 	defer connClose()
 
-	client := c.createClient(conn)
+	client := c.createFrontendNvmeClient(conn)
 	_, err = client.DeleteNvmeNamespace(
 		ctx,
 		&pb.DeleteNvmeNamespaceRequest{

--- a/storage/nvme_namespace_test.go
+++ b/storage/nvme_namespace_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 
 // Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
 package storage

--- a/storage/nvme_namespace_test.go
+++ b/storage/nvme_namespace_test.go
@@ -95,6 +95,7 @@ func TestCreateNvmeNamespace(t *testing.T) {
 				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
 					return mockClient
 				},
+				pb.NewFrontendVirtioBlkServiceClient,
 			)
 
 			response, err := c.CreateNvmeNamespace(ctx, namespaceID, subsystem, volume)
@@ -166,6 +167,7 @@ func TestDeleteNvmeNamespace(t *testing.T) {
 				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
 					return mockClient
 				},
+				pb.NewFrontendVirtioBlkServiceClient,
 			)
 
 			err := c.DeleteNvmeNamespace(ctx, testNamespaceName, true)

--- a/storage/nvme_subsystem.go
+++ b/storage/nvme_subsystem.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 
 // Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
 package storage
@@ -21,7 +21,7 @@ func (c *Client) CreateNvmeSubsystem(
 	}
 	defer connClose()
 
-	client := c.createClient(conn)
+	client := c.createFrontendNvmeClient(conn)
 	response, err := client.CreateNvmeSubsystem(
 		ctx,
 		&pb.CreateNvmeSubsystemRequest{
@@ -49,7 +49,7 @@ func (c *Client) DeleteNvmeSubsystem(
 	}
 	defer connClose()
 
-	client := c.createClient(conn)
+	client := c.createFrontendNvmeClient(conn)
 	_, err = client.DeleteNvmeSubsystem(
 		ctx,
 		&pb.DeleteNvmeSubsystemRequest{

--- a/storage/nvme_subsystem_test.go
+++ b/storage/nvme_subsystem_test.go
@@ -94,6 +94,7 @@ func TestCreateNvmeSubsystem(t *testing.T) {
 				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
 					return mockClient
 				},
+				pb.NewFrontendVirtioBlkServiceClient,
 			)
 
 			response, err := c.CreateNvmeSubsystem(ctx, subsystemID, nqn, hostnqn)
@@ -165,6 +166,7 @@ func TestDeleteNvmeSubsystem(t *testing.T) {
 				func(grpc.ClientConnInterface) pb.FrontendNvmeServiceClient {
 					return mockClient
 				},
+				pb.NewFrontendVirtioBlkServiceClient,
 			)
 
 			err := c.DeleteNvmeSubsystem(ctx, testSubsystemName, true)

--- a/storage/nvme_subsystem_test.go
+++ b/storage/nvme_subsystem_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 
 // Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
 package storage

--- a/storage/virtio_blk.go
+++ b/storage/virtio_blk.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Intel Corporation
+
+// Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
+package storage
+
+import (
+	"context"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// CreateVirtioBlk creates a virtio-blk controller
+func (c *Client) CreateVirtioBlk(
+	ctx context.Context,
+	id, volume string,
+	port, pf, vf, maxIoQPS uint,
+) (*pb.VirtioBlk, error) {
+	conn, connClose, err := c.connector.NewConn()
+	if err != nil {
+		return nil, err
+	}
+	defer connClose()
+
+	client := c.createVirtioBlkClient(conn)
+	response, err := client.CreateVirtioBlk(
+		ctx,
+		&pb.CreateVirtioBlkRequest{
+			VirtioBlkId: id,
+			VirtioBlk: &pb.VirtioBlk{
+				PcieId: &pb.PciEndpoint{
+					PortId:           wrapperspb.Int32(int32(port)),
+					PhysicalFunction: wrapperspb.Int32(int32(pf)),
+					VirtualFunction:  wrapperspb.Int32(int32(vf)),
+				},
+				VolumeNameRef: volume,
+				MaxIoQps:      int64(maxIoQPS),
+			},
+		})
+
+	return response, err
+}

--- a/storage/virtio_blk.go
+++ b/storage/virtio_blk.go
@@ -41,3 +41,26 @@ func (c *Client) CreateVirtioBlk(
 
 	return response, err
 }
+
+// DeleteVirtioBlk deletes a virtio-blk controller
+func (c *Client) DeleteVirtioBlk(
+	ctx context.Context,
+	name string,
+	allowMissing bool,
+) error {
+	conn, connClose, err := c.connector.NewConn()
+	if err != nil {
+		return err
+	}
+	defer connClose()
+
+	client := c.createVirtioBlkClient(conn)
+	_, err = client.DeleteVirtioBlk(
+		ctx,
+		&pb.DeleteVirtioBlkRequest{
+			Name:         name,
+			AllowMissing: allowMissing,
+		})
+
+	return err
+}

--- a/storage/virtio_blk.go
+++ b/storage/virtio_blk.go
@@ -23,7 +23,7 @@ func (c *Client) CreateVirtioBlk(
 	}
 	defer connClose()
 
-	client := c.createVirtioBlkClient(conn)
+	client := c.createFrontendVirtioBlkClient(conn)
 	response, err := client.CreateVirtioBlk(
 		ctx,
 		&pb.CreateVirtioBlkRequest{
@@ -54,7 +54,7 @@ func (c *Client) DeleteVirtioBlk(
 	}
 	defer connClose()
 
-	client := c.createVirtioBlkClient(conn)
+	client := c.createFrontendVirtioBlkClient(conn)
 	_, err = client.DeleteVirtioBlk(
 		ctx,
 		&pb.DeleteVirtioBlkRequest{

--- a/storage/virtio_blk_test.go
+++ b/storage/virtio_blk_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Intel Corporation
+
+// Package storage implements the go library for OPI to be used in storage, for example, CSI drivers
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/opiproject/godpu/mocks"
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestCreateVirtioBlk(t *testing.T) {
+	controllerID := "virtioblk0"
+	volume := "vol0"
+	testVirtioBlk := &pb.VirtioBlk{
+		PcieId: &pb.PciEndpoint{
+			PortId:           wrapperspb.Int32(0),
+			PhysicalFunction: wrapperspb.Int32(1),
+			VirtualFunction:  wrapperspb.Int32(2),
+		},
+		VolumeNameRef: volume,
+		MaxIoQps:      3,
+	}
+
+	tests := map[string]struct {
+		giveClientErr    error
+		giveConnectorErr error
+		wantErr          error
+		wantRequest      *pb.CreateVirtioBlkRequest
+		wantResponse     *pb.VirtioBlk
+		wantConnClosed   bool
+	}{
+		"successful call": {
+			giveConnectorErr: nil,
+			giveClientErr:    nil,
+			wantErr:          nil,
+			wantRequest: &pb.CreateVirtioBlkRequest{
+				VirtioBlkId: controllerID,
+				VirtioBlk:   proto.Clone(testVirtioBlk).(*pb.VirtioBlk),
+			},
+			wantResponse:   proto.Clone(testVirtioBlk).(*pb.VirtioBlk),
+			wantConnClosed: true,
+		},
+		"client err": {
+			giveConnectorErr: nil,
+			giveClientErr:    errors.New("Some client error"),
+			wantErr:          errors.New("Some client error"),
+			wantRequest: &pb.CreateVirtioBlkRequest{
+				VirtioBlkId: controllerID,
+				VirtioBlk:   proto.Clone(testVirtioBlk).(*pb.VirtioBlk),
+			},
+			wantResponse:   nil,
+			wantConnClosed: true,
+		},
+		"connector err": {
+			giveConnectorErr: errors.New("Some conn error"),
+			giveClientErr:    nil,
+			wantErr:          errors.New("Some conn error"),
+			wantRequest:      nil,
+			wantResponse:     nil,
+			wantConnClosed:   false,
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			mockClient := mocks.NewFrontendVirtioBlkServiceClient(t)
+			if tt.wantRequest != nil {
+				toReturn := proto.Clone(tt.wantResponse).(*pb.VirtioBlk)
+				mockClient.EXPECT().CreateVirtioBlk(ctx, tt.wantRequest).
+					Return(toReturn, tt.giveClientErr)
+			}
+
+			connClosed := false
+			mockConn := mocks.NewConnector(t)
+			mockConn.EXPECT().NewConn().Return(
+				&grpc.ClientConn{},
+				func() { connClosed = true },
+				tt.giveConnectorErr,
+			)
+
+			c, _ := NewWithArgs(
+				mockConn,
+				pb.NewFrontendNvmeServiceClient,
+				func(grpc.ClientConnInterface) pb.FrontendVirtioBlkServiceClient {
+					return mockClient
+				},
+			)
+
+			response, err := c.CreateVirtioBlk(ctx, controllerID, volume, 0, 1, 2, 3)
+
+			require.Equal(t, tt.wantErr, err)
+			require.True(t, proto.Equal(response, tt.wantResponse))
+			require.Equal(t, tt.wantConnClosed, connClosed)
+		})
+	}
+}


### PR DESCRIPTION
```bash
blk0=$(/dpu storage create virtio blk --id virtioblk0 --pf 0 --vf 0 --volume "$vol0")
/dpu storage delete virtio blk --name "$blk0"
```