### PR TITLE
Align command line parameter naming conventions

### DIFF
--- a/cmd/network/evpn-svi.go
+++ b/cmd/network/evpn-svi.go
@@ -56,7 +56,7 @@ func CreateSVI() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&name, "name", "", "SVI Name")
 	cmd.Flags().StringVar(&vrf, "vrf", "", "Must be unique")
-	cmd.Flags().StringVar(&logicalBridge, "logicalBridge", "", "Pair of vni and vlan_id must be unique")
+	cmd.Flags().StringVar(&logicalBridge, "logical-bridge", "", "Pair of vni and vlan_id must be unique")
 	cmd.Flags().StringVar(&mac, "mac", "", "GW MAC address, random MAC assigned if not specified")
 	cmd.Flags().StringSliceVar(&gwIPs, "gw-ips", nil, "List of GW IP addresses")
 	cmd.Flags().BoolVar(&ebgp, "ebgp", false, "Enable eBGP in VRF for tenants connected through this SVI")
@@ -66,7 +66,7 @@ func CreateSVI() *cobra.Command {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}
 
-	if err := cmd.MarkFlagRequired("logicalBridge"); err != nil {
+	if err := cmd.MarkFlagRequired("logical-bridge"); err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}
 
@@ -113,7 +113,7 @@ func DeleteSVI() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Specify the name of the BridgePort")
-	cmd.Flags().BoolVarP(&allowMissing, "allowMissing", "a", false, "Specify the name of the BridgePort")
+	cmd.Flags().BoolVarP(&allowMissing, "allow-missing", "a", false, "Specify the name of the BridgePort")
 
 	if err := cmd.MarkFlagRequired("name"); err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -245,7 +245,7 @@ func UpdateSVI() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringSliceVar(&updateMask, "update-mask", nil, "update mask")
-	cmd.Flags().BoolVarP(&allowMissing, "allowMissing", "a", false, "allow the missing")
+	cmd.Flags().BoolVarP(&allowMissing, "allow-missing", "a", false, "allow the missing")
 
 	return cmd
 }

--- a/cmd/storage/backend/nvme_controller.go
+++ b/cmd/storage/backend/nvme_controller.go
@@ -95,7 +95,7 @@ func newDeleteNvmeControllerCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "name of deleted remote controller")
-	cmd.Flags().BoolVar(&allowMissing, "allowMissing", false, "cmd succeeds if attempts to delete a resource that is not present")
+	cmd.Flags().BoolVar(&allowMissing, "allow-missing", false, "cmd succeeds if attempts to delete a resource that is not present")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 

--- a/cmd/storage/backend/nvme_path.go
+++ b/cmd/storage/backend/nvme_path.go
@@ -157,7 +157,7 @@ func newDeleteNvmePathCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "name of deleted nvme path")
-	cmd.Flags().BoolVar(&allowMissing, "allowMissing", false, "cmd succeeds if attempts to delete a resource that is not present")
+	cmd.Flags().BoolVar(&allowMissing, "allow-missing", false, "cmd succeeds if attempts to delete a resource that is not present")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 

--- a/cmd/storage/frontend/nvme_controller.go
+++ b/cmd/storage/frontend/nvme_controller.go
@@ -156,7 +156,7 @@ func newDeleteNvmeControllerCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "name of deleted controller")
-	cmd.Flags().BoolVar(&allowMissing, "allowMissing", false, "cmd succeeds if attempts to delete a resource that is not present")
+	cmd.Flags().BoolVar(&allowMissing, "allow-missing", false, "cmd succeeds if attempts to delete a resource that is not present")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 

--- a/cmd/storage/frontend/nvme_namespace.go
+++ b/cmd/storage/frontend/nvme_namespace.go
@@ -86,7 +86,7 @@ func newDeleteNvmeNamespaceCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "name of deleted namespace")
-	cmd.Flags().BoolVar(&allowMissing, "allowMissing", false, "cmd succeeds if attempts to delete a resource that is not present")
+	cmd.Flags().BoolVar(&allowMissing, "allow-missing", false, "cmd succeeds if attempts to delete a resource that is not present")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 

--- a/cmd/storage/frontend/nvme_subsystem.go
+++ b/cmd/storage/frontend/nvme_subsystem.go
@@ -85,7 +85,7 @@ func newDeleteNvmeSubsystemCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "name of deleted subsystem")
-	cmd.Flags().BoolVar(&allowMissing, "allowMissing", false, "cmd succeeds if attempts to delete a resource that is not present")
+	cmd.Flags().BoolVar(&allowMissing, "allow-missing", false, "cmd succeeds if attempts to delete a resource that is not present")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 

--- a/cmd/storage/frontend/virtio_blk.go
+++ b/cmd/storage/frontend/virtio_blk.go
@@ -93,7 +93,7 @@ func newDeleteVirtioBlkCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "name of deleted virtio-blk controller")
-	cmd.Flags().BoolVar(&allowMissing, "allowMissing", false, "cmd succeeds if attempts to delete a resource that is not present")
+	cmd.Flags().BoolVar(&allowMissing, "allow-missing", false, "cmd succeeds if attempts to delete a resource that is not present")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 


### PR DESCRIPTION
- Updated all command line parameter names to use kebab-case for consistency and readability.
- Replaced camelCase parameters with kebab-case equivalents:
  - logicalBridge to logical-bridge
  - allowMissing to allow-missing
  This change improves the readability and maintainability of the command line interface by using a consistent naming convention.
#428 